### PR TITLE
Add voting tests on MOB submission flow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,51 @@
+name: Pull Request
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/ISSUE_TEMPLATE/*'
+      - '.github/pull_request_template.md'
+      - 'LICENSE'
+      - 'README.md'
+      - 'docs/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit_tests:
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve packages
+        run: |
+          xcodebuild -project secant.xcodeproj \
+            -scheme zashi-internal \
+            -resolvePackageDependencies
+
+      - name: Run unit tests
+        run: |
+          set -o pipefail
+          xcodebuild test \
+            -project secant.xcodeproj \
+            -scheme zashi-internal \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -resultBundlePath TestResults.xcresult \
+            -only-testing:secantTests \
+            -skipPackagePluginValidation \
+            -skipMacroValidation \
+            CODE_SIGNING_ALLOWED=NO \
+            | xcpretty --color
+
+      - name: Upload test results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: TestResults
+          path: TestResults.xcresult

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -2600,6 +2600,7 @@
 		AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00102D00000100000002 /* VotingSessionTests.swift */; };
 		AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */; };
 		AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00212D00000100000002 /* VotingHelpersTests.swift */; };
+		AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00222D00000100000002 /* VotingCoordFlowCoordinatorTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -3184,6 +3185,7 @@
 		AD0D00102D00000100000002 /* VotingSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingSessionTests.swift; sourceTree = "<group>"; };
 		AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingAPIResponseParserTests.swift; sourceTree = "<group>"; };
 		AD0D00212D00000100000002 /* VotingHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingHelpersTests.swift; sourceTree = "<group>"; };
+		AD0D00222D00000100000002 /* VotingCoordFlowCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingCoordFlowCoordinatorTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -5457,6 +5459,7 @@
 			children = (
 				AD0D00102D00000100000002 /* VotingSessionTests.swift */,
 				AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */,
+				AD0D00222D00000100000002 /* VotingCoordFlowCoordinatorTests.swift */,
 				AD0D00212D00000100000002 /* VotingHelpersTests.swift */,
 			);
 			path = VotingTests;
@@ -7226,6 +7229,7 @@
 			files = (
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
 				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
+				AD0D00222D00000100000001 /* VotingCoordFlowCoordinatorTests.swift in Sources */,
 				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/secant.xcodeproj/project.pbxproj
+++ b/secant.xcodeproj/project.pbxproj
@@ -2598,6 +2598,8 @@
 		9EEBF9D62FBDAE2100DD38DB /* VotingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF9D22FBDAE2100DD38DB /* VotingHelpers.swift */; };
 		9EEBF9D72FBDAE2100DD38DB /* VotingHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EEBF9D22FBDAE2100DD38DB /* VotingHelpers.swift */; };
 		AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00102D00000100000002 /* VotingSessionTests.swift */; };
+		AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */; };
+		AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD0D00212D00000100000002 /* VotingHelpersTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -2605,8 +2607,8 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = 0D4E79FD26B364170058B01E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0D4E7A0426B364170058B01E;
-			remoteInfo = secant;
+			remoteGlobalIDString = 9E5AB4632C94777800065483;
+			remoteInfo = "zashi-internal";
 		};
 		0D4E7A2226B364180058B01E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -3180,6 +3182,8 @@
 		9EF8135A27ECC25E0075AF48 /* WalletStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletStorageTests.swift; sourceTree = "<group>"; };
 		9EF8135B27ECC25E0075AF48 /* UserPreferencesStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserPreferencesStorageTests.swift; sourceTree = "<group>"; };
 		AD0D00102D00000100000002 /* VotingSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingSessionTests.swift; sourceTree = "<group>"; };
+		AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingAPIResponseParserTests.swift; sourceTree = "<group>"; };
+		AD0D00212D00000100000002 /* VotingHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VotingHelpersTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -5452,6 +5456,8 @@
 			isa = PBXGroup;
 			children = (
 				AD0D00102D00000100000002 /* VotingSessionTests.swift */,
+				AD0D00202D00000100000002 /* VotingAPIResponseParserTests.swift */,
+				AD0D00212D00000100000002 /* VotingHelpersTests.swift */,
 			);
 			path = VotingTests;
 			sourceTree = "<group>";
@@ -5696,7 +5702,7 @@
 					};
 					0D4E7A1526B364180058B01E = {
 						CreatedOnToolsVersion = 12.5;
-						TestTargetID = 0D4E7A0426B364170058B01E;
+						TestTargetID = 9E5AB4632C94777800065483;
 					};
 					0D4E7A2026B364180058B01E = {
 						CreatedOnToolsVersion = 12.5;
@@ -7218,52 +7224,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9E139AAF2B07B3A600D104B8 /* ZatoshiStringRepresentationTests.swift in Sources */,
-				9E3451B529C8565500177D16 /* LoggerTests.swift in Sources */,
-				9E3451C229C857DB00177D16 /* TransactionSendingSnapshotTests.swift in Sources */,
-				9E34519E29C849B400177D16 /* WalletConfigProviderTests.swift in Sources */,
-				9E3451C029C857D400177D16 /* RecoveryPhraseDisplaySnapshotTests.swift in Sources */,
-				9E3451B629C8565500177D16 /* ZatoshiTests.swift in Sources */,
-				9E3451B829C856E700177D16 /* TransactionListTests.swift in Sources */,
-				9E34519529C4A4BF00177D16 /* ReceiveTests.swift in Sources */,
-				9E3451B929C857C000177D16 /* ReceiveSnapshotTests.swift in Sources */,
-				9E34519B29C4A90700177D16 /* DeeplinkTests.swift in Sources */,
-				9E3451BD29C857CC00177D16 /* ImportWalletSnapshotTests.swift in Sources */,
-				9E3451B429C8565500177D16 /* WalletStorageTests.swift in Sources */,
-				9E4938D82ACE8E8F003C4C1D /* SecurityWarningSnapshotTests.swift in Sources */,
-				9E3451C429C857DF00177D16 /* View+UIImage.swift in Sources */,
-				9E34519729C4A51100177D16 /* RecoveryPhraseBackupTests.swift in Sources */,
-				9E0C0D702AFB842B00D69A16 /* TransactionStateTests.swift in Sources */,
-				9E5B8E742B46E04E00CA3616 /* RestoreWalletTests.swift in Sources */,
-				9E683E472B0377F0002E7B5D /* WalletNukeTests.swift in Sources */,
-				9E3451BC29C857C800177D16 /* NotEnoughFeeSpaceSnapshots.swift in Sources */,
-				9E3451B229C8565500177D16 /* SecItemClientTests.swift in Sources */,
-				9E3451C629C857E700177D16 /* WelcomeSnapshotTests.swift in Sources */,
 				AD0D00102D00000100000001 /* VotingSessionTests.swift in Sources */,
-				9E3451C529C857E400177D16 /* TransactionListSnapshotTests.swift in Sources */,
-				9EEB06C62B344F1E00EEE50F /* SyncProgressTests.swift in Sources */,
-				9E34519C29C4A91A00177D16 /* HomeTests.swift in Sources */,
-				9E1FAFB72AF2C6D40084CA3D /* PrivateDataConsentSnapshotTests.swift in Sources */,
-				9E3451BB29C857C800177D16 /* HomeSnapshotTests.swift in Sources */,
-				9E3451AF29C855B200177D16 /* SensitiveDataTests.swift in Sources */,
-				9E3451A729C84E9900177D16 /* AppInitializationTests.swift in Sources */,
-				9E3451B029C855E600177D16 /* SettingsTests.swift in Sources */,
-				9E34519F29C849D300177D16 /* ImportWalletTests.swift in Sources */,
-				9E74CCD029DC0628003D6E32 /* ReviewRequestTests.swift in Sources */,
-				9E3451A029C84A2D00177D16 /* MultiLineTextFieldTests.swift in Sources */,
-				9E3451B729C8565500177D16 /* DatabaseFilesTests.swift in Sources */,
-				9E3451B129C8565500177D16 /* UserPreferencesStorageTests.swift in Sources */,
-				9E3451BA29C857C500177D16 /* BalanceBreakdownSnapshotTests.swift in Sources */,
-				9E3451A629C84B6600177D16 /* RootTests.swift in Sources */,
-				9E3451AE29C84F2800177D16 /* SendTests.swift in Sources */,
-				9EA7ED062B7A591C005979F4 /* ZatoshiStringRepresentationCommaTests.swift in Sources */,
-				9E34519A29C4A52F00177D16 /* BalanceBreakdownTests.swift in Sources */,
-				9E46919A2AD5735E0082D7DF /* TabsTests.swift in Sources */,
-				9E1FAFBA2AF2C7F20084CA3D /* PrivateDataConsentTests.swift in Sources */,
-				9E3451C329C857DD00177D16 /* SettingsSnapshotTests.swift in Sources */,
-				9E34519D29C8484D00177D16 /* HomeFeatureFlagTests.swift in Sources */,
-				9E3451A929C84EC000177D16 /* ScanTests.swift in Sources */,
-				9E3451A829C84EAF00177D16 /* DebugTests.swift in Sources */,
+				AD0D00202D00000100000001 /* VotingAPIResponseParserTests.swift in Sources */,
+				AD0D00212D00000100000001 /* VotingHelpersTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8672,7 +8635,7 @@
 /* Begin PBXTargetDependency section */
 		0D4E7A1826B364180058B01E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 0D4E7A0426B364170058B01E /* secant-testnet */;
+			target = 9E5AB4632C94777800065483 /* zashi-internal */;
 			targetProxy = 0D4E7A1726B364180058B01E /* PBXContainerItemProxy */;
 		};
 		0D4E7A2326B364180058B01E /* PBXTargetDependency */ = {
@@ -8968,7 +8931,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG UNREDACTED";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/secant-testnet.app/secant-testnet";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zashi-internal.app/zashi-internal";
 			};
 			name = Debug;
 		};
@@ -8990,7 +8953,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/secant-testnet.app/secant-testnet";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zashi-internal.app/zashi-internal";
 			};
 			name = "Release-Testflight";
 		};
@@ -9345,7 +9308,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/secant-testnet.app/secant-testnet";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/zashi-internal.app/zashi-internal";
 			};
 			name = "Release-AppStore";
 		};

--- a/secant.xcodeproj/xcshareddata/xcschemes/zashi-internal.xcscheme
+++ b/secant.xcodeproj/xcshareddata/xcschemes/zashi-internal.xcscheme
@@ -28,7 +28,29 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      shouldAutocreateTestPlan = "YES">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9E5AB4632C94777800065483"
+            BuildableName = "zashi-internal.app"
+            BlueprintName = "zashi-internal"
+            ReferencedContainer = "container:secant.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0D4E7A1526B364180058B01E"
+               BuildableName = "secantTests.xctest"
+               BlueprintName = "secantTests"
+               ReferencedContainer = "container:secant.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
+++ b/secant/Sources/Features/Voting/DelegationSigning/DelegationSigningStore.swift
@@ -313,19 +313,7 @@ struct DelegationSigningView: View {
         }
 
         let bundleTotal = bundles[bundleIndex].reduce(UInt64(0)) { $0 + $1.value }
-        return String(
-            localizable: .coinVoteDelegationSigningMemoMessage(
-                pollTitle,
-                rawZecString(bundleTotal)
-            )
-        )
-    }
-
-    private static func rawZecString(_ zatoshi: UInt64) -> String {
-        let whole = zatoshi / 100_000_000
-        let fractional = String(zatoshi % 100_000_000)
-        let paddedFractional = String(repeating: "0", count: max(0, 8 - fractional.count)) + fractional
-        return "\(whole).\(paddedFractional)"
+        return votingAuthorizationMemo(pollTitle: pollTitle, rawWeight: bundleTotal)
     }
 
     // MARK: - Action buttons

--- a/secant/Sources/Features/Voting/VotingHelpers.swift
+++ b/secant/Sources/Features/Voting/VotingHelpers.swift
@@ -469,6 +469,22 @@ enum VotingErrorMapper {
 
 // MARK: - Note bundling (Swift mirror of zcash_voting::chunk_notes)
 
+func votingRawZecString(_ zatoshi: UInt64) -> String {
+    let whole = zatoshi / 100_000_000
+    let fractional = String(zatoshi % 100_000_000)
+    let paddedFractional = String(repeating: "0", count: max(0, 8 - fractional.count)) + fractional
+    return "\(whole).\(paddedFractional)"
+}
+
+func votingAuthorizationMemo(pollTitle: String, rawWeight: UInt64) -> String {
+    String(
+        localizable: .coinVoteDelegationSigningMemoMessage(
+            pollTitle,
+            votingRawZecString(rawWeight)
+        )
+    )
+}
+
 struct BundleResult {
     let bundles: [[NoteInfo]]
     let eligibleWeight: UInt64

--- a/secantTests/VotingTests/VotingAPIResponseParserTests.swift
+++ b/secantTests/VotingTests/VotingAPIResponseParserTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-@testable import secant_testnet
+@testable import zashi_internal
 
 final class VotingAPIResponseParserTests: XCTestCase {
     func testParseJSONObjectAcceptsRegularJSONObject() throws {

--- a/secantTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
+++ b/secantTests/VotingTests/VotingCoordFlowCoordinatorTests.swift
@@ -1,0 +1,320 @@
+import ComposableArchitecture
+import Foundation
+import XCTest
+@testable import zashi_internal
+
+final class VotingCoordFlowCoordinatorTests: XCTestCase {
+    func testBatchVoteSubmittedMovesDraftIntoSubmittedVotes() {
+        let metadata = VotingMetadataBox()
+        var state = VotingCoordFlow.State()
+        state.roundCache[roundId] = roundSession(
+            drafts: [
+                1: .option(0),
+                2: .option(1)
+            ]
+        )
+
+        withDependencies {
+            $0.votingMetadata = votingMetadataClient(metadata)
+        } operation: {
+            _ = VotingCoordFlow().reduceBatchVoteSubmitted(
+                &state,
+                roundId: roundId,
+                proposalId: 1,
+                choice: .option(0)
+            )
+        }
+
+        let session = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(session.draftVotes, [2: .option(1)])
+        XCTAssertEqual(session.votes, [1: .option(0)])
+        XCTAssertEqual(metadata.drafts[roundId], ["2": 1])
+        XCTAssertEqual(metadata.submittedVotes[roundId], ["1": 0])
+    }
+
+    func testBatchSubmissionCompletedAcceptsPartialBallotWhenDraftsAreDrained() {
+        let metadata = VotingMetadataBox()
+        var state = VotingCoordFlow.State()
+        state.roundCache[roundId] = roundSession(
+            votingWeight: 50_000_000,
+            votes: [
+                1: .option(0),
+                3: .option(1)
+            ]
+        )
+
+        withDependencies {
+            $0.votingMetadata = votingMetadataClient(metadata)
+        } operation: {
+            _ = VotingCoordFlow().reduceBatchSubmissionCompleted(
+                &state,
+                roundId: roundId,
+                successCount: 2,
+                failCount: 0
+            )
+        }
+
+        let session = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(session.batchSubmissionStatus, .completed(successCount: 2))
+        XCTAssertEqual(session.voteRecord?.votingWeight, 50_000_000)
+        XCTAssertEqual(session.voteRecord?.proposalCount, 2)
+        XCTAssertEqual(state.voteRecords[roundId]?.proposalCount, 2)
+        XCTAssertEqual(metadata.records[roundId]?.proposalCount, 2)
+    }
+
+    func testBatchSubmissionCompletedFailsWhenDraftsRemain() {
+        var state = VotingCoordFlow.State()
+        state.roundCache[roundId] = roundSession(
+            drafts: [2: .option(1)],
+            votes: [1: .option(0)]
+        )
+
+        _ = VotingCoordFlow().reduceBatchSubmissionCompleted(
+            &state,
+            roundId: roundId,
+            successCount: 1,
+            failCount: 0
+        )
+
+        let session = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(
+            session.batchSubmissionStatus,
+            .submissionFailed(
+                error: String(localizable: .coinVoteSubmissionGenericBatchFailure),
+                submittedCount: 1,
+                totalCount: 2
+            )
+        )
+        XCTAssertNil(session.voteRecord)
+    }
+
+    func testBatchSubmissionCompletedFailsWhenVoteErrorsExist() {
+        var session = roundSession(votes: [1: .option(0)])
+        session.batchVoteErrors = [2: "server unavailable"]
+        var state = VotingCoordFlow.State()
+        state.roundCache[roundId] = session
+
+        _ = VotingCoordFlow().reduceBatchSubmissionCompleted(
+            &state,
+            roundId: roundId,
+            successCount: 1,
+            failCount: 0
+        )
+
+        let updated = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(
+            updated.batchSubmissionStatus,
+            .submissionFailed(
+                error: "server unavailable",
+                submittedCount: 1,
+                totalCount: 1
+            )
+        )
+        XCTAssertNil(updated.voteRecord)
+    }
+
+    func testIntermediateKeystoneSignatureAdvancesToNextBundle() {
+        var session = roundSession()
+        session.bundleCount = 2
+        session.currentKeystoneBundleIndex = 0
+        session.keystoneSigningStatus = .awaitingSignature
+        var state = VotingCoordFlow.State()
+        state.roundCache[roundId] = session
+
+        _ = VotingCoordFlow().reduceKeystoneBundleSignatureStored(
+            &state,
+            roundId: roundId,
+            signature: signature(byte: 1),
+            bundleIndex: 0,
+            bundleCount: 2
+        )
+
+        let updated = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(updated.currentKeystoneBundleIndex, 1)
+        XCTAssertEqual(updated.keystoneBundleSignatures, [signature(byte: 1)])
+        XCTAssertEqual(updated.keystoneSigningStatus, .idle)
+        XCTAssertFalse(updated.isDelegationProofInFlight)
+        XCTAssertNil(updated.pendingVotingPczt)
+        XCTAssertNil(updated.pendingUnsignedDelegationPczt)
+    }
+
+    func testFinalKeystoneSignatureMovesToFinalizingAuthorization() {
+        var session = roundSession()
+        session.bundleCount = 2
+        session.currentKeystoneBundleIndex = 1
+        session.keystoneSigningStatus = .awaitingSignature
+        var state = VotingCoordFlow.State()
+        state.path.append(.delegationSigning(DelegationSigning.State(roundId: roundId)))
+        state.roundCache[roundId] = session
+
+        _ = VotingCoordFlow().reduceKeystoneBundleSignatureStored(
+            &state,
+            roundId: roundId,
+            signature: signature(byte: 2),
+            bundleIndex: 1,
+            bundleCount: 2
+        )
+
+        let updated = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(updated.keystoneBundleSignatures, [signature(byte: 2)])
+        XCTAssertEqual(updated.keystoneSigningStatus, .finalizingAuthorization)
+        XCTAssertEqual(updated.delegationProofStatus, .generating(progress: 0))
+        XCTAssertTrue(updated.isDelegationProofInFlight)
+        XCTAssertEqual(updated.batchSubmissionStatus, .authorizing)
+        XCTAssertEqual(updated.voteSubmissionStep, .authorizingVote)
+        XCTAssertFalse(isDelegationSigningTop(state))
+    }
+
+    func testSkippingRemainingKeystoneBundlesKeepsOnlySignedWeight() {
+        var session = roundSession(
+            votingWeight: 100_000_000,
+            notes: [
+                note(value: 31_568_000, position: 0),
+                note(value: 26_000_000, position: 1),
+                note(value: 13_000_000, position: 2),
+                note(value: 12_500_000, position: 3),
+                note(value: 5_000_000, position: 4),
+                note(value: 4_000_000, position: 5),
+                note(value: 3_000_000, position: 6),
+                note(value: 3_000_000, position: 7),
+                note(value: 2_000_000, position: 8),
+                note(value: 1_000_000, position: 9)
+            ]
+        )
+        session.bundleCount = 2
+        session.keystoneBundleSignatures = [signature(byte: 1)]
+        var state = VotingCoordFlow.State()
+        state.path.append(.delegationSigning(DelegationSigning.State(roundId: roundId)))
+        state.roundCache[roundId] = session
+
+        _ = VotingCoordFlow().reduceSkipRemainingKeystoneBundles(&state, roundId: roundId)
+
+        let updated = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(updated.bundleCount, 1)
+        XCTAssertEqual(updated.votingWeight, 87_500_000)
+        XCTAssertEqual(updated.eligibleBundleCount, 2)
+        XCTAssertEqual(updated.eligibleVotingWeight, 100_000_000)
+        XCTAssertEqual(updated.keystoneSigningStatus, .finalizingAuthorization)
+        XCTAssertEqual(updated.batchSubmissionStatus, .authorizing)
+        XCTAssertEqual(updated.voteSubmissionStep, .authorizingVote)
+        XCTAssertFalse(isDelegationSigningTop(state))
+    }
+
+    func testDelegationRejectedResetsKeystoneLoopButPreservesVotes() {
+        var session = roundSession(
+            drafts: [2: .option(1)],
+            votes: [1: .option(0)]
+        )
+        session.bundleCount = 2
+        session.currentKeystoneBundleIndex = 1
+        session.keystoneBundleSignatures = [signature(byte: 1)]
+        session.keystoneSigningStatus = .awaitingSignature
+        session.batchSubmissionStatus = .authorizing
+        var state = VotingCoordFlow.State()
+        state.pendingBatchSubmission = true
+        state.path.append(.delegationSigning(DelegationSigning.State(roundId: roundId)))
+        state.roundCache[roundId] = session
+
+        _ = VotingCoordFlow().coordinatorReduce().reduce(
+            into: &state,
+            action: .delegationRejected(roundId: roundId)
+        )
+
+        let updated = tryUnwrap(state.roundCache[roundId])
+        XCTAssertEqual(updated.currentKeystoneBundleIndex, 0)
+        XCTAssertTrue(updated.keystoneBundleSignatures.isEmpty)
+        XCTAssertEqual(updated.keystoneSigningStatus, .idle)
+        XCTAssertEqual(updated.batchSubmissionStatus, .idle)
+        XCTAssertEqual(updated.draftVotes, [2: .option(1)])
+        XCTAssertEqual(updated.votes, [1: .option(0)])
+        XCTAssertFalse(state.pendingBatchSubmission)
+        XCTAssertFalse(isDelegationSigningTop(state))
+    }
+
+    private let roundId = "round-1"
+
+    private func roundSession(
+        votingWeight: UInt64 = 0,
+        drafts: [UInt32: VoteChoice] = [:],
+        votes: [UInt32: VoteChoice] = [:],
+        notes: [NoteInfo] = []
+    ) -> RoundSession {
+        var session = RoundSession(roundId: roundId)
+        session.votingWeight = votingWeight
+        session.draftVotes = drafts
+        session.votes = votes
+        session.walletNotes = notes
+        return session
+    }
+
+    private func signature(byte: UInt8) -> KeystoneBundleSignature {
+        KeystoneBundleSignature(
+            sig: Data(repeating: byte, count: 64),
+            sighash: Data(repeating: byte + 1, count: 32),
+            rk: Data(repeating: byte + 2, count: 32)
+        )
+    }
+
+    private func note(value: UInt64, position: UInt64) -> NoteInfo {
+        let byte = UInt8(position % UInt64(UInt8.max))
+        return NoteInfo(
+            commitment: Data(repeating: byte, count: 32),
+            nullifier: Data(repeating: byte, count: 32),
+            value: value,
+            position: position,
+            diversifier: Data(repeating: byte, count: 11),
+            rho: Data(repeating: byte, count: 32),
+            rseed: Data(repeating: byte, count: 32),
+            scope: 0,
+            ufvkStr: "ufvk-\(position)"
+        )
+    }
+
+    private func isDelegationSigningTop(_ state: VotingCoordFlow.State) -> Bool {
+        guard case .delegationSigning = state.path.last else {
+            return false
+        }
+        return true
+    }
+
+    private func tryUnwrap<T>(
+        _ value: T?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> T {
+        do {
+            return try XCTUnwrap(value, file: file, line: line)
+        } catch {
+            fatalError("XCTUnwrap failed")
+        }
+    }
+
+    private func votingMetadataClient(
+        _ box: VotingMetadataBox
+    ) -> VotingMetadataProviderClient {
+        var client = VotingMetadataProviderClient()
+        client.load = { _ in }
+        client.store = { _ in }
+        client.resetAccount = { _ in }
+        client.reset = {}
+        client.loadDrafts = { box.drafts[$0] ?? [:] }
+        client.setDrafts = { drafts, roundId in box.drafts[roundId] = drafts }
+        client.clearDrafts = { roundId in box.drafts[roundId] = [:] }
+        client.loadSubmittedVotes = { box.submittedVotes[$0] ?? [:] }
+        client.setSubmittedVotes = { votes, roundId in
+            box.submittedVotes[roundId] = votes
+        }
+        client.clearSubmittedVotes = { roundId in box.submittedVotes[roundId] = [:] }
+        client.record = { box.records[$0] }
+        client.allRecords = { box.records }
+        client.setRecord = { record, roundId in box.records[roundId] = record }
+        client.clearRecord = { roundId in box.records.removeValue(forKey: roundId) }
+        return client
+    }
+}
+
+private final class VotingMetadataBox: @unchecked Sendable {
+    var drafts: [String: [String: UInt32]] = [:]
+    var submittedVotes: [String: [String: UInt32]] = [:]
+    var records: [String: PersistedVotingRecord] = [:]
+}

--- a/secantTests/VotingTests/VotingHelpersTests.swift
+++ b/secantTests/VotingTests/VotingHelpersTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import XCTest
+@testable import zashi_internal
+
+final class VotingHelpersTests: XCTestCase {
+    func testSmartBundlesUsesRustOrderingAndPerBundleQuantization() {
+        let notes = [
+            note(value: 31_568_000, position: 0),
+            note(value: 26_000_000, position: 1),
+            note(value: 13_000_000, position: 2),
+            note(value: 12_500_000, position: 3),
+            note(value: 5_000_000, position: 4),
+            note(value: 4_000_000, position: 5),
+            note(value: 3_000_000, position: 6),
+            note(value: 3_000_000, position: 7),
+            note(value: 2_000_000, position: 8),
+            note(value: 1_000_000, position: 9)
+        ]
+
+        let result = notes.smartBundles()
+
+        XCTAssertEqual(result.bundles.map { $0.map(\.position) }, [
+            [0, 1, 2, 3, 4],
+            [5, 6, 7, 8, 9]
+        ])
+        XCTAssertEqual(result.bundles.map(Self.total), [
+            88_068_000,
+            13_000_000
+        ])
+        XCTAssertEqual(result.eligibleWeight, 100_000_000)
+        XCTAssertEqual(result.droppedCount, 0)
+    }
+
+    func testSmartBundlesDropsTrailingDustBundle() {
+        let notes = [
+            note(value: 30_000_000, position: 0),
+            note(value: 20_000_000, position: 1),
+            note(value: 10_000_000, position: 2),
+            note(value: 10_000_000, position: 3),
+            note(value: 5_000_000, position: 4),
+            note(value: 1_000_000, position: 5)
+        ]
+
+        let result = notes.smartBundles()
+
+        XCTAssertEqual(result.bundles.map { $0.map(\.position) }, [[0, 1, 2, 3, 4]])
+        XCTAssertEqual(result.eligibleWeight, 75_000_000)
+        XCTAssertEqual(result.droppedCount, 1)
+    }
+
+    func testVotingAuthorizationMemoUsesRawEightDecimalBundleTotal() {
+        XCTAssertEqual(votingRawZecString(31_568_000), "0.31568000")
+        XCTAssertEqual(
+            votingAuthorizationMemo(pollTitle: "Shielded Poll", rawWeight: 31_568_000),
+            "I am authorizing this hotkey managed by my wallet to vote on Shielded Poll with 0.31568000 ZEC."
+        )
+    }
+
+    private static func total(_ notes: [NoteInfo]) -> UInt64 {
+        notes.reduce(UInt64(0)) { $0 + $1.value }
+    }
+
+    private func note(value: UInt64, position: UInt64) -> NoteInfo {
+        let byte = UInt8(position % UInt64(UInt8.max))
+        return NoteInfo(
+            commitment: Data(repeating: byte, count: 32),
+            nullifier: Data(repeating: byte, count: 32),
+            value: value,
+            position: position,
+            diversifier: Data(repeating: byte, count: 11),
+            rho: Data(repeating: byte, count: 32),
+            rseed: Data(repeating: byte, count: 32),
+            scope: 0,
+            ufvkStr: "ufvk-\(position)"
+        )
+    }
+}

--- a/secantTests/VotingTests/VotingHelpersTests.swift
+++ b/secantTests/VotingTests/VotingHelpersTests.swift
@@ -27,6 +27,10 @@ final class VotingHelpersTests: XCTestCase {
             88_068_000,
             13_000_000
         ])
+        XCTAssertEqual(result.bundles.map { quantizeWeight(Self.total($0)) }, [
+            87_500_000,
+            12_500_000
+        ])
         XCTAssertEqual(result.eligibleWeight, 100_000_000)
         XCTAssertEqual(result.droppedCount, 0)
     }
@@ -54,6 +58,84 @@ final class VotingHelpersTests: XCTestCase {
             votingAuthorizationMemo(pollTitle: "Shielded Poll", rawWeight: 31_568_000),
             "I am authorizing this hotkey managed by my wallet to vote on Shielded Poll with 0.31568000 ZEC."
         )
+    }
+
+    func testSubmittedVotesByProposalRequiresEveryExpectedBundle() {
+        let records = [
+            VoteRecord(proposalId: 1, bundleIndex: 0, choice: .option(0), submitted: true),
+            VoteRecord(proposalId: 1, bundleIndex: 1, choice: .option(0), submitted: true),
+            VoteRecord(proposalId: 2, bundleIndex: 0, choice: .option(1), submitted: true),
+            VoteRecord(proposalId: 3, bundleIndex: 0, choice: .option(1), submitted: false),
+            VoteRecord(proposalId: 3, bundleIndex: 1, choice: .option(1), submitted: true)
+        ]
+
+        XCTAssertEqual(
+            submittedVotesByProposal(records, bundleCount: 2),
+            [1: .option(0)]
+        )
+    }
+
+    func testSubmittedVotesByProposalAllowsLegacyUnknownBundleCount() {
+        let records = [
+            VoteRecord(proposalId: 1, bundleIndex: 0, choice: .option(0), submitted: true),
+            VoteRecord(proposalId: 2, bundleIndex: 0, choice: .option(1), submitted: false)
+        ]
+
+        XCTAssertEqual(
+            submittedVotesByProposal(records, bundleCount: 0),
+            [1: .option(0)]
+        )
+    }
+
+    func testSyntheticAbstainOnlyMatchesUiGeneratedChoice() {
+        let proposal = VotingProposal(
+            id: 1,
+            title: "ZIP Poll",
+            description: "",
+            options: [
+                VoteOption(index: 0, label: "Support"),
+                VoteOption(index: 1, label: "Oppose")
+            ]
+        )
+        let proposalWithNativeAbstain = VotingProposal(
+            id: 2,
+            title: "ZIP Poll",
+            description: "",
+            options: [
+                VoteOption(index: 0, label: "Support"),
+                VoteOption(index: 1, label: "Oppose"),
+                VoteOption(index: 2, label: "Abstain")
+            ]
+        )
+
+        XCTAssertTrue(Voting.isSyntheticAbstain(choice: .option(2), proposal: proposal))
+        XCTAssertFalse(Voting.isSyntheticAbstain(choice: .option(1), proposal: proposal))
+        XCTAssertFalse(Voting.isSyntheticAbstain(choice: .option(3), proposal: proposalWithNativeAbstain))
+        XCTAssertFalse(Voting.isSyntheticAbstain(choice: .option(2), proposal: nil))
+    }
+
+    func testVoteRecordReportsSkippedKeystoneBundles() {
+        let skippedRecord = Voting.VoteRecord(
+            votedAt: Date(timeIntervalSince1970: 1_000),
+            votingWeight: 25_000_000,
+            proposalCount: 2,
+            eligibleVotingWeight: 100_000_000,
+            submittedBundleCount: 1,
+            totalBundleCount: 4
+        )
+        let completeRecord = Voting.VoteRecord(
+            votedAt: Date(timeIntervalSince1970: 1_000),
+            votingWeight: 100_000_000,
+            proposalCount: 2,
+            eligibleVotingWeight: 100_000_000,
+            submittedBundleCount: 4,
+            totalBundleCount: 4
+        )
+
+        XCTAssertEqual(skippedRecord.skippedKeystoneBundleCount, 3)
+        XCTAssertTrue(skippedRecord.hasSkippedKeystoneBundles)
+        XCTAssertNil(completeRecord.skippedKeystoneBundleCount)
+        XCTAssertFalse(completeRecord.hasSkippedKeystoneBundles)
     }
 
     private static func total(_ notes: [NoteInfo]) -> UInt64 {

--- a/secantTests/VotingTests/VotingSessionTests.swift
+++ b/secantTests/VotingTests/VotingSessionTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 import Foundation
-@testable import VotingModels
+@testable import zashi_internal
 
 final class VotingSessionTests: XCTestCase {
     func testLastMomentBufferUsesFortyPercentForShortRounds() throws {


### PR DESCRIPTION
## Summary

- add a focused `secantTests` PR gate for the MOB submission-flow branch
- add voting helper coverage for smart bundles, raw memo totals, submitted vote hydration, synthetic abstain handling, and skipped Keystone bundle metadata
- add voting coordinator coverage for batch submission and Keystone bundle state transitions

## Testing

```sh
FX_ENABLE_GLASS=0 xcodebuild test \
  -project secant.xcodeproj \
  -scheme zashi-internal \
  -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
  -derivedDataPath /tmp/zodl-current-dd \
  -resultBundlePath /tmp/zodl-current-secantTests-clean.xcresult \
  -only-testing:secantTests \
  -skipPackagePluginValidation \
  -skipMacroValidation \
  CODE_SIGNING_ALLOWED=NO
```

Result: 26 tests, 0 failures.
